### PR TITLE
remove driver_ids.h from vfs0090.c

### DIFF
--- a/libfprint/drivers/vfs0090.c
+++ b/libfprint/drivers/vfs0090.c
@@ -34,8 +34,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "driver_ids.h"
-
 #include "vfs0090.h"
 
 #define STRINGIZE(s) #s


### PR DESCRIPTION
Missed in https://github.com/3v1n0/libfprint/commit/a61675850f3c3578a1e51f5ccbdf06f3f00412aa

There are a lot more build errors here but this is a basic fix... is there a stable commit somewhere that I can use?