### PR TITLE
mark git optional in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -160,7 +160,7 @@ foreach driver: drivers
             error('pixman is required for imaging support')
         endif
 
-        git = find_program('git')
+        git = find_program('git', required: false)
         if git.found()
             message('Updating the vfs0090 submodule')
             c = run_command(git, ['submodule', 'update', '--init', '--recursive'])


### PR DESCRIPTION
what it says on the tin :) this will make `git.found` in the next line work as intended