### PR TITLE
Add NixOS overlay to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,29 @@ Install packages:
 - `git clone https://github.com/3v1n0/libfprint`
 - `meson libfprint libfprint/_build && sudo ninja -C libfprint/_build install`
 
+#### NixOS
+
+- Enable fprintd as usual via `services.fprintd.enable = true;`
+- Apply this overlay (possibly update rev and sha256, if necessary):
+
+```
+self: super: {
+  libfprint = super.libfprint.overrideAttrs (
+    up: {
+      version = "1.90.1+vfs0090.1";
+      src = super.fetchFromGitHub {
+        owner = "3v1n0";
+        repo = "libfprint";
+        rev = "48f3bb005d256477658273f0592442143740408e";
+        sha256 = "sha256-Ari94tq9Q7LAxh/TOdoRG9J3kAzEnitwwPA5E5HFxxc=";
+        fetchSubmodules = true;
+      };
+      buildInputs = up.buildInputs ++ ([ self.openssl ]);
+    }
+  );
+}
+```
+
 #### Other distros
  - `git clone https://github.com/3v1n0/libfprint`
  - `meson libfprint libfprint/_build && sudo ninja -C libfprint/_build install`


### PR DESCRIPTION
The overlay as specified is all I need to make everything work as expected on NixOS on my t460p :)

(note that specifying overlays is a bit iffy in readmes, since they refer to a specific commit in a repository, but that commit can't include the overlay info itself. oh well, people who use overlays are likely used to updating the commit where necessary :shrug:)